### PR TITLE
Remove hardcoded dependency versions for inputmask and libphonenumber

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,8 +51,6 @@ android {
 }
 
 dependencies {
-    androidTestImplementation("androidx.room:room-testing:2.6.1")
-
     implementation(libs.androidx.paging.runtime)
     implementation(libs.inputmask)
     implementation(libs.kotlin.stdlib)
@@ -86,6 +84,4 @@ dependencies {
     androidTestImplementation(libs.androidx.espresso.core)
 
     androidTestImplementation(libs.androidx.room.testing)
-    implementation("com.redmadrobot:input-mask-android:6.1.0")
-    implementation("com.googlecode.libphonenumber:libphonenumber:8.13.38")
 }


### PR DESCRIPTION
## Summary
- use version catalog for input mask and libphonenumber
- clean up redundant Room testing dependency

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689bb88f73308326b71ecd064b943b20