### PR TITLE
Use shared phone formatter for contact forms

### DIFF
--- a/app/src/main/java/com/example/otebookbeta/ContactDetailFragment.kt
+++ b/app/src/main/java/com/example/otebookbeta/ContactDetailFragment.kt
@@ -24,6 +24,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.textfield.MaterialAutoCompleteTextView
 import com.google.android.material.textfield.TextInputLayout
+import com.example.otebookbeta.utils.setupPhoneInput
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
@@ -266,6 +267,8 @@ class ContactDetailFragment : BaseFragment() {
         // Имя
         binding.fullNameInput.addTextChangedListener(SimpleWatcher { checkForChanges() })
 
+        // Телефон: форматирование и отслеживание изменений
+        setupPhoneInput(binding.phoneInput, binding.phoneLayout) { checkForChanges() }
 
         // Остальные поля — просто трекаем изменения
         listOf(


### PR DESCRIPTION
## Summary
- replace custom phone mask in AddContactFragment with shared formatter
- apply same phone formatter in ContactDetailFragment

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689bdb0022dc83268533f5d823a660f7