### PR TITLE
Use shared phone formatter for contact forms

### DIFF
--- a/app/src/main/java/com/example/otebookbeta/AddContactFragment.kt
+++ b/app/src/main/java/com/example/otebookbeta/AddContactFragment.kt
@@ -24,9 +24,7 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
-import kotlin.math.min
-import com.redmadrobot.inputmask.MaskedTextChangedListener
-import com.google.i18n.phonenumbers.PhoneNumberUtil
+import com.example.otebookbeta.utils.setupPhoneInput
 
 @AndroidEntryPoint
 class AddContactFragment : BaseFragment() {
@@ -140,14 +138,8 @@ class AddContactFragment : BaseFragment() {
                 calendar.get(Calendar.DAY_OF_MONTH)
             ).show()
         }
-        // --- Телефон: сразу "+7 " и маска +7 (999) 999-99-99 ---
-        if (binding.phoneInput.text.isNullOrBlank()) {
-            binding.phoneInput.setText("+7 ")
-            binding.phoneInput.setSelection(binding.phoneInput.text?.length ?: 0)
-        }
-        binding.phoneInput.addTextChangedListener(RuPhoneMaskWatcher { text, hasError ->
-            binding.phoneLayout.error = if (hasError) "Неверный формат российского телефона (+7 (XXX) XXX-XX-XX)" else null
-        })
+        // Телефон: форматирование +7 (999) 999-99-99
+        setupPhoneInput(binding.phoneInput, binding.phoneLayout)
     }
 
     private fun setupFocusValidation() {
@@ -222,8 +214,7 @@ class AddContactFragment : BaseFragment() {
     private fun validatePhone(): Boolean {
         val text = binding.phoneInput.text?.toString().orEmpty()
         val digits = text.replace("[^0-9]".toRegex(), "")
-        // Пустое поле — это только "+7 " (т.е. единственная цифра 7)
-        if (digits == "7" || digits.isEmpty()) {
+        if (digits.isEmpty()) {
             binding.phoneLayout.error = null
             return true
         }
@@ -347,62 +338,5 @@ class AddContactFragment : BaseFragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
-    }
-}
-
-/** Маска телефона РФ: всегда "+7 " + (999) 999-99-99 *///////
-private class RuPhoneMaskWatcher(
-    private val onValidate: (text: String, hasError: Boolean) -> Unit
-) : TextWatcher {
-    private var isFormatting = false
-    private val maxLen = 18 // длина строки вида +7 (999) 999-99-99
-
-    override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
-    override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
-
-    override fun afterTextChanged(s: Editable?) {
-        if (isFormatting) return
-        isFormatting = true
-
-        val rawDigits = (s?.toString() ?: "").replace("[^0-9]".toRegex(), "")
-        // гарантируем ведущую "7"
-        val withCountry = when {
-            rawDigits.isEmpty() -> "7"
-            rawDigits[0] == '8' -> "7" + rawDigits.substring(1)
-            rawDigits[0] != '7' -> "7$rawDigits"
-            else -> rawDigits
-        }
-        // 10 национальных цифр после "7"
-        val national = withCountry.drop(1).take(10)
-
-        val formatted = formatRu(national)
-        if (formatted != s.toString()) {
-            s?.replace(0, s.length, formatted)
-        }
-
-        val hasError = national.isNotEmpty() && national.length != 10
-        onValidate(formatted, hasError)
-
-        isFormatting = false
-    }
-
-    private fun formatRu(national: String): String {
-        if (national.isEmpty()) return "+7 "
-        val sb = StringBuilder("+7 ")
-        sb.append("(").append(national.substring(0, min(3, national.length)))
-        if (national.length >= 3) sb.append(")")
-        if (national.length > 3) {
-            sb.append(" ")
-            sb.append(national.substring(3, min(6, national.length)))
-        }
-        if (national.length > 6) {
-            sb.append("-")
-            sb.append(national.substring(6, min(8, national.length)))
-        }
-        if (national.length > 8) {
-            sb.append("-")
-            sb.append(national.substring(8, min(10, national.length)))
-        }
-        return if (sb.length > maxLen) sb.substring(0, maxLen) else sb.toString()
     }
 }

--- a/app/src/main/java/com/example/otebookbeta/ContactDetailFragment.kt
+++ b/app/src/main/java/com/example/otebookbeta/ContactDetailFragment.kt
@@ -24,6 +24,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.textfield.MaterialAutoCompleteTextView
 import com.google.android.material.textfield.TextInputLayout
+import com.example.otebookbeta.utils.setupPhoneInput
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
@@ -266,6 +267,8 @@ class ContactDetailFragment : BaseFragment() {
         // Имя
         binding.fullNameInput.addTextChangedListener(SimpleWatcher { checkForChanges() })
 
+        // Телефон: форматирование и отслеживание изменений
+        setupPhoneInput(binding.phoneInput, binding.phoneLayout) { checkForChanges() }
 
         // Остальные поля — просто трекаем изменения
         listOf(

--- a/app/src/main/java/com/example/otebookbeta/utils/PhoneInputFormatter.kt
+++ b/app/src/main/java/com/example/otebookbeta/utils/PhoneInputFormatter.kt
@@ -29,10 +29,10 @@ fun setupPhoneInput(
             val input = s.toString().replace("[^0-9]".toRegex(), "")
             val digits = when {
                 input.isEmpty() -> ""
-                input.startsWith("8") -> "7${'$'}{input.substring(1)}"
-                input.startsWith("9") && input.length <= 10 -> "7${'$'}input"
+                input.startsWith("8") -> "7${input.substring(1)}"
+                input.startsWith("9") && input.length <= 10 -> "7$input"
                 input.startsWith("7") -> input
-                else -> "7${'$'}input"
+                else -> "7$input"
             }
 
             val formatted = buildFormattedPhone(digits)
@@ -59,18 +59,30 @@ fun setupPhoneInput(
 }
 
 private fun buildFormattedPhone(digits: String): String {
-    return when (digits.length) {
-        0 -> ""
-        1 -> "+7"
-        in 2..4 -> "+7 (${digits.substring(1)}"
-        in 5..7 -> "+7 (${digits.substring(1, minOf(4, digits.length))}) ${digits.substring(minOf(4, digits.length))}"
-        in 8..9 -> "+7 (${digits.substring(1, 4)}) ${digits.substring(4, minOf(7, digits.length))}-${digits.substring(minOf(7, digits.length))}"
-        else -> {
-            val code = digits.substring(1, minOf(4, digits.length))
-            val middle = digits.substring(minOf(4, digits.length), minOf(7, digits.length))
-            val last1 = digits.substring(minOf(7, digits.length), minOf(9, digits.length))
-            val last2 = digits.substring(minOf(9, digits.length), minOf(11, digits.length))
-            "+7 (${code}) ${middle}-${last1}${if (last2.isNotEmpty()) "-${last2}" else ""}"
-        }
+    if (digits.isEmpty()) return ""
+
+    val sb = StringBuilder("+7")
+
+    if (digits.length >= 2) {
+        sb.append(" (")
+        sb.append(digits.substring(1, minOf(4, digits.length)))
+        if (digits.length >= 4) sb.append(")")
     }
+
+    if (digits.length >= 5) {
+        sb.append(" ")
+        sb.append(digits.substring(4, minOf(7, digits.length)))
+    }
+
+    if (digits.length >= 8) {
+        sb.append("-")
+        sb.append(digits.substring(7, minOf(9, digits.length)))
+    }
+
+    if (digits.length >= 10) {
+        sb.append("-")
+        sb.append(digits.substring(9, minOf(11, digits.length)))
+    }
+
+    return sb.toString()
 }


### PR DESCRIPTION
## Summary
- replace custom phone mask in AddContactFragment with shared formatter
- apply same phone formatter in ContactDetailFragment
- fix phone input formatter to avoid literal text and remove prefilled `+7`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689bdb0022dc83268533f5d823a660f7