### PR TITLE
Remove redundant wrappers from contact list layout

### DIFF
--- a/app/src/main/res/layout/fragment_contact_list.xml
+++ b/app/src/main/res/layout/fragment_contact_list.xml
@@ -38,32 +38,21 @@
         </androidx.appcompat.widget.Toolbar>
     </com.google.android.material.appbar.AppBarLayout>
 
-    <androidx.core.widget.NestedScrollView
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/contacts_recyclerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+        android:clipToPadding="false"
+        android:padding="8dp"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:listitem="@layout/item_contact_card"/>
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical">
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/contacts_recyclerView"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:clipToPadding="false"
-                android:padding="8dp"
-                tools:listitem="@layout/item_contact_card"/>
-
-            <TextView
-                android:id="@+id/empty_state"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:gravity="center"
-                android:text="Нет контактов"
-                android:textAppearance="?attr/textAppearanceHeadline6"
-                android:visibility="gone"/>
-        </LinearLayout>
-    </androidx.core.widget.NestedScrollView>
+    <TextView
+        android:id="@+id/empty_state"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:text="Нет контактов"
+        android:textAppearance="?attr/textAppearanceHeadline6"
+        android:visibility="gone"/>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
## Summary
- simplify contact list layout by placing RecyclerView directly in CoordinatorLayout
- overlay empty state TextView above list for better empty-state handling

## Testing
- `bash gradlew test` (fails: Unable to tunnel through proxy, HTTP 403)

------
https://chatgpt.com/codex/tasks/task_e_689c3e2bc7b883268fac44c2141cb02a